### PR TITLE
Adding needed mock requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     install_requires=[
         'Kotti>=0.9b2',
         'pyramid_deform<=0.2',
+        'mock>=1.0'
     ],
     message_extractors={
         'kotti_settings': [


### PR DESCRIPTION
When using kotti_settings on a fresh kotti install, I get this traceback :

```
File "***/local/lib/python2.7/site-packages/kotti_settings-0.1-py2.7.egg/kotti_settings/tests/test_events.py", line 1, in <module>
     from mock import patch
ImportError: No module named mock
```

My fix for this was to add mock in the setup.py requirements.
